### PR TITLE
fix image names on push

### DIFF
--- a/images/push
+++ b/images/push
@@ -18,7 +18,7 @@ do
     log_action "Pushing image ${pushed_source} to ${pushed_target}..." && \
     buildah push --creds \
         ${maintainer}:${DOCKER_REGISTRY_SECRET} \
-        ${podman_image} docker://${maintainer}/molecule-${image}:${tag} \
+        ${podman_image} docker://${maintainer}/${image}:${tag} \
     && log_success "${green}Pushed image ${greenb}${pushed_source}${green} to ${greenb}${pushed_target}${green}." \
     || log_error "Could not push image  to ${redb}${pushed_target}${red}."
 done


### PR DESCRIPTION
Hello jam82,
I noticed that the images will be pushed with an additional "molecule-". The name is correct in the `${pushed_target}` variable used in the log_action before.

"Liebe Grüße" ;-)
Fabian
